### PR TITLE
improved game over/restart animations

### DIFF
--- a/Assets/Animations/gameOverCircle.controller
+++ b/Assets/Animations/gameOverCircle.controller
@@ -46,23 +46,6 @@ AnimatorStateMachine:
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: 0}
---- !u!1109 &-4188148005584247843
-AnimatorTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: restart
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 7357507624217990989}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 1
 --- !u!1107 &-536769845473772685
 AnimatorStateMachine:
   serializedVersion: 5
@@ -74,17 +57,13 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 780763544827996887}
-    m_Position: {x: 300, y: 80, z: 0}
+    m_Position: {x: 480, y: 120, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -5520799347550867640}
     m_Position: {x: 300, y: -60, z: 0}
-  - serializedVersion: 1
-    m_State: {fileID: 7357507624217990989}
-    m_Position: {x: 300, y: 170, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
-  m_EntryTransitions:
-  - {fileID: -4188148005584247843}
+  m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: 50, y: 20, z: 0}
@@ -106,13 +85,7 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
-  - m_Name: restart
-    m_Type: 9
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -135,7 +108,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions: []
   m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 7357507624217990989}
+  m_DstState: {fileID: 0}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
@@ -183,7 +156,7 @@ AnimatorTransition:
   m_Name: 
   m_Conditions: []
   m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 7357507624217990989}
+  m_DstState: {fileID: 0}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
@@ -213,29 +186,3 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1102 &7357507624217990989
-AnimatorState:
-  serializedVersion: 5
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: restartCircle
-  m_Speed: 1
-  m_CycleOffset: 0
-  m_Transitions: []
-  m_StateMachineBehaviours: []
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: a73d49158913b4b29992c4bedbffaa76, type: 2}
-  m_Tag: 
-  m_SpeedParameter: 
-  m_MirrorParameter: 
-  m_CycleOffsetParameter: 
-  m_TimeParameter: 

--- a/Assets/Animations/gameOverCircle_2.controller
+++ b/Assets/Animations/gameOverCircle_2.controller
@@ -42,6 +42,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
+  - m_Name: inGame
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -55,6 +61,33 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
+--- !u!1102 &3179268635892107440
+AnimatorState:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: restartCircleInvis
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 7928142578923694655}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 2fd78eabb780f4a0aafba253e910ee0e, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1101 &3814945343793814624
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -64,7 +97,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: restart
+    m_ConditionEvent: inGame
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 8677111897570699595}
@@ -91,10 +124,13 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 8677111897570699595}
-    m_Position: {x: 260, y: 60, z: 0}
+    m_Position: {x: 520, y: 70, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -7700262190111622173}
-    m_Position: {x: 230, y: -50, z: 0}
+    m_Position: {x: 410, y: -20, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3179268635892107440}
+    m_Position: {x: 250, y: 50, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -104,7 +140,32 @@ AnimatorStateMachine:
   m_EntryPosition: {x: 50, y: 120, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: -7700262190111622173}
+  m_DefaultState: {fileID: 3179268635892107440}
+--- !u!1101 &7928142578923694655
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: restart
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -7700262190111622173}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.000000009347847
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &8677111897570699595
 AnimatorState:
   serializedVersion: 5

--- a/Assets/Animations/restartCircleInvis.anim
+++ b/Assets/Animations/restartCircleInvis.anim
@@ -6,7 +6,7 @@ AnimationClip:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: gameOverPanel
+  m_Name: restartCircleInvis
   serializedVersion: 6
   m_Legacy: 0
   m_Compressed: 0
@@ -15,30 +15,14 @@ AnimationClip:
   m_CompressedRotationCurves: []
   m_EulerCurves: []
   m_PositionCurves: []
-  m_ScaleCurves:
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: {x: 30, y: 30, z: 30}
-        inSlope: {x: 0, y: 0, z: 0}
-        outSlope: {x: 0, y: 0, z: 0}
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: {x: 0, y: 0.33333334, z: 0.33333334}
-        outWeight: {x: 0, y: 0.33333334, z: 0.33333334}
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    path: 
+  m_ScaleCurves: []
   m_FloatCurves:
   - curve:
       serializedVersion: 2
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.101960786
+        value: 0.21960786
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -57,7 +41,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.21176471
+        value: 0.21960786
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -76,7 +60,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.32941177
+        value: 0.21960786
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -87,6 +71,25 @@ AnimationClip:
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_Color.b
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Color.a
     path: 
     classID: 212
     script: {fileID: 0}
@@ -114,13 +117,6 @@ AnimationClip:
       isPPtrCurve: 1
     - serializedVersion: 2
       path: 0
-      attribute: 3
-      script: {fileID: 0}
-      typeID: 4
-      customType: 0
-      isPPtrCurve: 0
-    - serializedVersion: 2
-      path: 0
       attribute: 2526845255
       script: {fileID: 0}
       typeID: 212
@@ -140,6 +136,13 @@ AnimationClip:
       typeID: 212
       customType: 0
       isPPtrCurve: 0
+    - serializedVersion: 2
+      path: 0
+      attribute: 304273561
+      script: {fileID: 0}
+      typeID: 212
+      customType: 0
+      isPPtrCurve: 0
     pptrCurveMapping:
     - {fileID: 21300000, guid: 4987780a8b60940b7b75a9700af22a8c, type: 3}
   m_AnimationClipSettings:
@@ -152,7 +155,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 0
+    m_LoopTime: 1
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0
@@ -168,64 +171,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 30
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalScale.x
-    path: 
-    classID: 4
-    script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 30
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalScale.y
-    path: 
-    classID: 4
-    script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 30
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalScale.z
-    path: 
-    classID: 4
-    script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0.101960786
+        value: 0.21960786
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -244,7 +190,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.21176471
+        value: 0.21960786
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -263,7 +209,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.32941177
+        value: 0.21960786
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -274,6 +220,25 @@ AnimationClip:
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_Color.b
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Color.a
     path: 
     classID: 212
     script: {fileID: 0}

--- a/Assets/Animations/restartCircleInvis.anim.meta
+++ b/Assets/Animations/restartCircleInvis.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2fd78eabb780f4a0aafba253e910ee0e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Images/Pigeon/pigeon.controller
+++ b/Assets/Images/Pigeon/pigeon.controller
@@ -37,7 +37,7 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: -8572620447708749617}
-    m_Position: {x: 200, y: 0, z: 0}
+    m_Position: {x: 240, y: 60, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []

--- a/Assets/RestartGame.cs
+++ b/Assets/RestartGame.cs
@@ -15,6 +15,7 @@ public class RestartGame : MonoBehaviour
     [SerializeField] private Button quit;
     [SerializeField] private GameObject player;
     private Vector3 scoreCardHidden;
+    private Vector3 scoreCardShown;
 
     private int score;
     
@@ -24,31 +25,19 @@ public class RestartGame : MonoBehaviour
         score = PlayerPrefs.GetInt("Score");
         scoreGUI.horizontalOverflow = HorizontalWrapMode.Overflow;
         scoreCardHidden = new Vector3(0, 10f, 0);
-        //restart.Text = "Restart";
-        //quit.Text = "Quit";
+        scoreCardShown = Vector3.zero;
         restart.onClick.AddListener(RestartOnClick);
         quit.onClick.AddListener(Quit);
     }
     
     void FixedUpdate()
     {
-        Vector3 scoreBoardPosition = new Vector3(Camera.main.transform.position.x, Camera.main.transform.position.y, 0);
-        scoreCard.transform.position = Vector3.Lerp(scoreCard.transform.position, scoreBoardPosition, 0.125f);
+        scoreCard.transform.position = Vector3.Lerp(scoreCard.transform.position, scoreCardShown, 0.125f);
     }
     
     void OnGUI()
     {    
         scoreGUI.text = score.ToString();
-        
-        /*
-        if (GUI.Button(new Rect(Screen.width/2-50,Screen.height/2 +150,100,40),"Retry?"))
-        {
-            StartCoroutine(LoadScene());
-        }
-        if(GUI.Button(new Rect(Screen.width/2-50,Screen.height/2 +200,100,40),"Quit"))
-        {
-            Application.Quit();
-        }*/
     }
 
     void RestartOnClick()
@@ -63,10 +52,21 @@ public class RestartGame : MonoBehaviour
     
     IEnumerator LoadScene()
     {
-        scoreCard.transform.position = Vector3.Lerp(scoreCard.transform.position, scoreCardHidden, 0.125f);
-        restartGameAnim.SetTrigger("restart");
+        //Debug.Log(scoreCardHidden);
+        //Debug.Log("transform.position: " + scoreCard.transform.position);
+        //restartGameAnim.SetTrigger("restart");
+        
+        float moveDurationTimer = 0.0f;
+        float moveDuration = 1.5f;
+
+        while (moveDurationTimer < moveDuration) 
+        {
+            moveDurationTimer += Time.deltaTime;
+            // Lerp using initial value!
+            transform.position = Vector2.Lerp(scoreCard.transform.position, scoreCardHidden, moveDurationTimer / moveDuration);
+            yield return null;
+        }
         PlayerPrefs.SetInt("Restart", 1);
-        yield return new WaitForSeconds(1.5f);
         SceneManager.LoadScene(nextScene);
     }
 }

--- a/Assets/Scenes/GameOver.unity
+++ b/Assets/Scenes/GameOver.unity
@@ -460,7 +460,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 659134444}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 30, z: 10}
+  m_LocalPosition: {x: 0, y: 10, z: 10}
   m_LocalScale: {x: 1.3516457, y: 1.3516457, z: 1.3516457}
   m_Children: []
   m_Father: {fileID: 1672377404}
@@ -483,7 +483,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!95 &695224609
 Animator:
   serializedVersion: 3
@@ -602,7 +602,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 913, y: -649}
+  m_AnchoredPosition: {x: 870, y: -649}
   m_SizeDelta: {x: 713.22784, y: 237.74258}
   m_Pivot: {x: 0.34321925, y: 0.5}
 --- !u!114 &1224275035
@@ -882,7 +882,7 @@ Camera:
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.21960786, g: 0.21960786, b: 0.21960786, a: 0}
+  m_BackGroundColor: {r: 0.101960786, g: 0.21176471, b: 0.32941177, a: 0}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0

--- a/Assets/Scenes/startingSequence.unity
+++ b/Assets/Scenes/startingSequence.unity
@@ -583,7 +583,7 @@ Transform:
   m_LocalScale: {x: 0.09, y: 0.09, z: 0.09}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!61 &332351670
 BoxCollider2D:
@@ -622,7 +622,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 6bb35df43263043ac87018fdb6842fba, type: 3}
-  m_PlayOnAwake: 1
+  m_PlayOnAwake: 0
   m_Volume: 0.6
   m_Pitch: 1
   Loop: 0
@@ -739,11 +739,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameOverAnim: {fileID: 1630621286}
+  restartAnim: {fileID: 1728015643}
   nextScene: gameOver
   Ground:
     serializedVersion: 2
     m_Bits: 256
-  BGMusic: {fileID: 1206511677}
+  BGMusicObject: {fileID: 1206511677}
 --- !u!1 &376996241
 GameObject:
   m_ObjectHideFlags: 0
@@ -755,6 +756,7 @@ GameObject:
   - component: {fileID: 376996242}
   - component: {fileID: 376996244}
   - component: {fileID: 376996243}
+  - component: {fileID: 376996245}
   m_Layer: 5
   m_Name: Score
   m_TagString: Untagged
@@ -825,6 +827,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 376996241}
   m_CullTransparentMesh: 0
+--- !u!225 &376996245
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 376996241}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -929,6 +943,7 @@ Transform:
   - {fileID: 2145616382}
   - {fileID: 169660082}
   - {fileID: 1206511678}
+  - {fileID: 1728015642}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1123,7 +1138,7 @@ RectTransform:
   - {fileID: 1671867949}
   - {fileID: 833740626}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1144,7 +1159,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   welcomeMessage: {fileID: 1671867946}
   pigeonMessage: {fileID: 833740623}
+  score: {fileID: 376996245}
   pigeonSpawn: {fileID: 169660081}
+  gameOverCircle: {fileID: 1630621285}
 --- !u!1 &795269986
 GameObject:
   m_ObjectHideFlags: 0
@@ -1209,7 +1226,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &819110622
 GameObject:
@@ -1294,7 +1311,7 @@ Transform:
   m_LocalScale: {x: -0.1029578, y: 0.102957785, z: 0.102957785}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!60 &819110625
 PolygonCollider2D:
@@ -1771,7 +1788,7 @@ Transform:
   m_LocalScale: {x: 0.25327864, y: 0.25327864, z: 0.25327864}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!50 &865320038
 Rigidbody2D:
@@ -1905,7 +1922,7 @@ Transform:
   m_LocalScale: {x: 0.15084255, y: 0.15084255, z: 0.15084255}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!61 &927969226
 BoxCollider2D:
@@ -2032,7 +2049,7 @@ Transform:
   m_LocalScale: {x: 0.15084255, y: 0.15084255, z: 0.15084255}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!61 &1174792368
 BoxCollider2D:
@@ -2070,7 +2087,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1206511678}
   - component: {fileID: 1206511680}
-  - component: {fileID: 1206511679}
   m_Layer: 0
   m_Name: BG_Music
   m_TagString: Untagged
@@ -2092,19 +2108,6 @@ Transform:
   m_Father: {fileID: 519420032}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1206511679
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1206511677}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f165985d9e3f4f7bb9257b9b9192a0f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  stop: 0
 --- !u!82 &1206511680
 AudioSource:
   m_ObjectHideFlags: 0
@@ -2116,7 +2119,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 8e46d686bd98743fbaf51d159252e3c0, type: 3}
-  m_PlayOnAwake: 1
+  m_PlayOnAwake: 0
   m_Volume: 1
   m_Pitch: 1
   Loop: 1
@@ -2201,87 +2204,6 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!1 &1215548132
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1215548133}
-  - component: {fileID: 1215548135}
-  - component: {fileID: 1215548134}
-  m_Layer: 5
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1215548133
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1215548132}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -5.269989, y: 3.8200073}
-  m_SizeDelta: {x: 5.896309, y: 1.8600192}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1215548134
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1215548132}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 45
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 2
-    m_MaxSize: 45
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 'Score:
-
-'
---- !u!222 &1215548135
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1215548132}
-  m_CullTransparentMesh: 0
 --- !u!1 &1455420810
 GameObject:
   m_ObjectHideFlags: 0
@@ -2571,6 +2493,108 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 300}
   m_SizeDelta: {x: 221.14966, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1728015641
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1728015642}
+  - component: {fileID: 1728015644}
+  - component: {fileID: 1728015643}
+  m_Layer: 0
+  m_Name: restartCircle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1728015642
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728015641}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.049987793, y: 0.039978027, z: 10}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 519420032}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &1728015643
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728015641}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: a0a4a105122f149ad8d0c60e91d42726, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!212 &1728015644
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728015641}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 3
+  m_Sprite: {fileID: 21300000, guid: 57d42695d4b0c42caacd4e1c2e2f3e7c, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 8.66, y: 8.66}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &2145616381
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CanvasFade.cs
+++ b/Assets/Scripts/CanvasFade.cs
@@ -7,24 +7,47 @@ public class CanvasFade : MonoBehaviour
     // Start is called before the first frame update
     [SerializeField] private CanvasGroup welcomeMessage;
     [SerializeField] private CanvasGroup pigeonMessage;
+    [SerializeField] private CanvasGroup score;
     [SerializeField] private GameObject pigeonSpawn;
+    [SerializeField] private GameObject gameOverCircle;
     void Start()
     {
         welcomeMessage.alpha = 0;
         pigeonMessage.alpha = 0;
+        score.alpha = 0;
         StartCoroutine(FadeInOut(welcomeMessage, pigeonMessage));
+    }
+
+    void Update()
+    {
+        if (gameOverCircle.transform.localScale.x > 1)
+        {
+            welcomeMessage.alpha = 0f;
+            score.alpha = 0f;
+            pigeonMessage.alpha = 0f;
+        }
     }
 
     IEnumerator FadeInOut(CanvasGroup firstMessage, CanvasGroup secondMessage)
     {
-        StartCoroutine(FadeText(firstMessage, 0f, 1f, 0.5f));
-        yield return new WaitForSeconds(4f);
-        StartCoroutine(FadeText(firstMessage, 1f, 0f, 0.5f));
-        yield return new WaitForSeconds(2f);
-        StartCoroutine(FadeText(secondMessage, 0f, 1f, 0.5f));
-        yield return new WaitForSeconds(3f);
-        StartCoroutine(FadeText(secondMessage, 1f, 0f, 0.5f));
-        pigeonSpawn.GetComponent<PigeonSpawn>().canSpawn = true;
+        bool restarted = false;
+        if (PlayerPrefs.GetInt("Restart") == 1)
+        {
+            yield return new WaitForSeconds(1.5f);
+            restarted = true;
+        }
+        score.alpha = 1f;
+        if (!restarted)
+        {
+            StartCoroutine(FadeText(firstMessage, 0f, 1f, 0.5f));
+            yield return new WaitForSeconds(4f);
+            StartCoroutine(FadeText(firstMessage, 1f, 0f, 0.5f));
+            yield return new WaitForSeconds(2f);
+            StartCoroutine(FadeText(secondMessage, 0f, 1f, 0.5f));
+            yield return new WaitForSeconds(3f);
+            StartCoroutine(FadeText(secondMessage, 1f, 0f, 0.5f));
+            pigeonSpawn.GetComponent<PigeonSpawn>().canSpawn = true;
+        }
     }
 
     IEnumerator FadeText(CanvasGroup text, float startAlpha, float endAlpha, float duration)

--- a/Assets/Scripts/CatMovement.cs
+++ b/Assets/Scripts/CatMovement.cs
@@ -13,6 +13,7 @@ public class CatMovement : MonoBehaviour
     
     /**** for restarting game ****/
     [SerializeField] private Animator gameOverAnim;
+    [SerializeField] private Animator restartAnim;
     [SerializeField] private string nextScene;
     private BoxCollider2D boxcollider2D;
     
@@ -30,17 +31,25 @@ public class CatMovement : MonoBehaviour
 
     /**** cat sound effects ****/
     private AudioSource meow;
-    [SerializeField] private GameObject BGMusic;
+    [SerializeField] private GameObject BGMusicObject;
+    private AudioSource BGMusic;
     
     void Awake()
     {
         anim = GetComponent<Animator>();
         boxcollider2D = transform.GetComponent<BoxCollider2D>();
+        BGMusic = BGMusicObject.GetComponent<AudioSource>();
         meow = GetComponent<AudioSource>();
+
         
         if (PlayerPrefs.GetInt("Restart") == 1)
         {
-            gameOverAnim.SetTrigger("restart");
+            StartCoroutine(RestartAnimation());
+        }
+        else
+        {
+            BGMusic.Play();
+            meow.Play();
         }
     }
 
@@ -176,7 +185,7 @@ public class CatMovement : MonoBehaviour
         if (other.CompareTag("Street") || other.CompareTag("Pigeon"))
         {
             transform.position = Vector3.zero;
-            BGMusic.GetComponent<BGMusic>().stop = true;
+            BGMusic.Stop();
             meow.Play();
             StartCoroutine(LoadScene());
         }
@@ -187,5 +196,15 @@ public class CatMovement : MonoBehaviour
         gameOverAnim.SetTrigger("end");
         yield return new WaitForSeconds(1f);
         SceneManager.LoadScene(nextScene);
+    }
+
+    IEnumerator RestartAnimation()
+    {
+        restartAnim.SetTrigger("restart");
+        restartAnim.SetTrigger("inGame");
+        yield return new WaitForSeconds(1f);
+        PlayerPrefs.SetInt("Restart", 0);
+        meow.Play();
+        BGMusic.Play();
     }
 }


### PR DESCRIPTION
1. the blue circle animation that goes from restart to startingSequence now works
2. instructions only appear the first time you're playing the game
3. scores and instructions disappear when player loses and the screen is obscured by the growing blue circle
4. upon restart, score, meow sounds, and music only appear when the game is fully loaded and the blue circle is getting smaller
5. STILL NEED TO FIX: the scoreCard in the gameOver scene is supposed to fly directly up and out of view when the player clicks restart. for some reason, that's not happening